### PR TITLE
10 compile error on ubuntu 22 04

### DIFF
--- a/builds/includes/helperOC/ValFuncs/visSetIm.hpp
+++ b/builds/includes/helperOC/ValFuncs/visSetIm.hpp
@@ -17,9 +17,9 @@
 
 #if defined(VISUALIZE_BY_OPENCV)
 #include <opencv2/opencv.hpp>
-#if !defined(CV_VERSION_EPOCH) && (CV_VERSION_MAJOR == 3)	/* OpenCV 3.0 */
+#if !defined(CV_VERSION_EPOCH) && (CV_VERSION_MAJOR >= 3)	/* OpenCV 3.0 or later*/
 #define HELPEROC_OPNECV_3_X
-#endif /* OpenCV 3.0 */
+#endif /* OpenCV 3.0 or later */
 #if !defined(HELPEROC_OPNECV_3_X)
 namespace cv {
 	static const int LINE_AA = CV_AA;

--- a/builds/includes/macro.hpp
+++ b/builds/includes/macro.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <algorithm>
 #include <numeric>
+#include <limits>
 #include <typedef.hpp>
 
 #if defined(WIN32)	// Windows

--- a/sources/modules/helperOC/ComputeOptTraj.cpp
+++ b/sources/modules/helperOC/ComputeOptTraj.cpp
@@ -177,7 +177,6 @@ bool helperOC::ComputeOptTraj_impl::operator()(
 				size = cv::Size((int)std::ceil(org_width * actual_fx), (int)std::ceil(org_height * actual_fy));
 			}
 
-			const int width = size.width;
 			const int height = size.height;
 			const FLOAT_TYPE left_offset = x0MinMax.first;
 			const FLOAT_TYPE top_offset = x1MinMax.first;

--- a/sources/modules/helperOC/Makefile
+++ b/sources/modules/helperOC/Makefile
@@ -75,7 +75,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -117,8 +117,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 endif
 ifeq ($(OPENMP_ON), Y)
 ifeq ($(UNAME),Darwin)

--- a/sources/modules/helperOC/ValFuncs/HJIPDE.cpp
+++ b/sources/modules/helperOC/ValFuncs/HJIPDE.cpp
@@ -271,7 +271,6 @@ bool HJIPDE_impl::solve(beacls::FloatVec& dst_tau,
 	beacls::IntegerVec plotDims;
 	beacls::FloatVec projpt;
 	bool deleteLastPlot = false;
-	bool need_light = false;
 #if defined(VISUALIZE_BY_OPENCV)
 	cv::Mat HJIPDE_img;
 	cv::Mat HJIPDE_initial_img;
@@ -302,7 +301,6 @@ bool HJIPDE_impl::solve(beacls::FloatVec& dst_tau,
 		windowName = std::string("HJIPDE");
 		cv::namedWindow(windowName.c_str(), 0);
 #endif
-		need_light = true;
 		if (obsMode == HJIPDE::ObsModeType_Static) {
 			beacls::FloatVec tmp_obstacle;
 			if (obstacle_s8_i) {

--- a/sources/modules/helperOC/ValFuncs/visSetIm.cpp
+++ b/sources/modules/helperOC/ValFuncs/visSetIm.cpp
@@ -201,15 +201,14 @@ bool helperOC::visSetIm_single(
 	const beacls::FloatVec& data,
 	const std::vector<float>& color,
 	const beacls::FloatVec& level,
-	const bool applyLight,
-	const size_t sliceDim,
+	const bool,
+	const size_t,
 	const cv::Size dsize,
 	const double fx,
 	const double fy
 ) {
 	//!<  Slice last dimension by default
 	const size_t gDim = g->get_num_of_dimensions();
-	size_t modifiedSliceDim = (sliceDim != std::numeric_limits<size_t>::max()) ? sliceDim : gDim - 1;
 	cv::Mat fliped_src;
 	if (!src_img.empty()) {
 		cv::flip(src_img, fliped_src, 0);

--- a/sources/modules/levelset/Core/interpn.cpp
+++ b/sources/modules/levelset/Core/interpn.cpp
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <iterator>
 #include <cmath>
+#include <limits>
 
 namespace beacls {
 	static bool convertv(

--- a/sources/modules/levelset/Makefile
+++ b/sources/modules/levelset/Makefile
@@ -73,7 +73,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -115,8 +115,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 endif
 ifeq ($(OPENMP_ON), Y)
 ifeq ($(UNAME),Darwin)

--- a/sources/modules/levelset/SpatialDerivative/UpwindFirst/UpwindFirst.cpp
+++ b/sources/modules/levelset/SpatialDerivative/UpwindFirst/UpwindFirst.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cmath>
 #include <numeric>
+#include <cstdio>
 #include <macro.hpp>
 
 bool levelset::checkEquivalentApprox(

--- a/sources/samples/DubinsCar_RS/Makefile
+++ b/sources/samples/DubinsCar_RS/Makefile
@@ -103,7 +103,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -145,8 +145,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/MyPlane_test0/Makefile
+++ b/sources/samples/MyPlane_test0/Makefile
@@ -99,7 +99,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -141,8 +141,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/MyPlane_test1/Makefile
+++ b/sources/samples/MyPlane_test1/Makefile
@@ -99,7 +99,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -141,8 +141,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/MyPlane_test2/Makefile
+++ b/sources/samples/MyPlane_test2/Makefile
@@ -99,7 +99,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -141,8 +141,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/P5D_Dubins_RS/Makefile
+++ b/sources/samples/P5D_Dubins_RS/Makefile
@@ -103,7 +103,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -145,8 +145,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/Plane4D_test/Makefile
+++ b/sources/samples/Plane4D_test/Makefile
@@ -98,7 +98,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -140,8 +140,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/PlaneCAvoid_test/Makefile
+++ b/sources/samples/PlaneCAvoid_test/Makefile
@@ -101,7 +101,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -143,8 +143,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/Plane_test/Makefile
+++ b/sources/samples/Plane_test/Makefile
@@ -98,7 +98,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -140,8 +140,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/Quad4D_test/Makefile
+++ b/sources/samples/Quad4D_test/Makefile
@@ -99,7 +99,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -141,8 +141,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/air3D/Makefile
+++ b/sources/samples/air3D/Makefile
@@ -97,7 +97,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -139,8 +139,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/plane4D/Makefile
+++ b/sources/samples/plane4D/Makefile
@@ -98,7 +98,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -140,8 +140,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/samples/test_reachiability/Makefile
+++ b/sources/samples/test_reachiability/Makefile
@@ -96,7 +96,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -138,8 +138,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 endif
 ifeq ($(OPENMP_ON), Y)
 ifeq ($(UNAME),Darwin)

--- a/sources/unittests/Dissipation/Makefile
+++ b/sources/unittests/Dissipation/Makefile
@@ -97,7 +97,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -139,8 +139,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/unittests/HJIPDE_solve/Makefile
+++ b/sources/unittests/HJIPDE_solve/Makefile
@@ -96,7 +96,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -138,8 +138,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/unittests/HamFunc/Makefile
+++ b/sources/unittests/HamFunc/Makefile
@@ -97,7 +97,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -139,8 +139,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/unittests/SpatialDerivative/Makefile
+++ b/sources/unittests/SpatialDerivative/Makefile
@@ -97,7 +97,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -139,8 +139,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)

--- a/sources/unittests/Term/Makefile
+++ b/sources/unittests/Term/Makefile
@@ -97,7 +97,7 @@ ifeq ($(UNAME),Darwin)
 	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5
 endif
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz -lhdf5_cpp
+	LDFLAGS += -L$(MATIO_LIB_DIR) -lmatio -lz $(shell pkg-config --libs hdf5)
 endif
 CFLAGS += -I$(MATIO_INC_DIR)
 
@@ -139,8 +139,14 @@ ifeq ($(GUI_ON), Y)
 	CFLAGS	+= -DVISUALIZE_WITH_GUI
 endif
 	CFLAGS	+= -DVISUALIZE_BY_OPENCV
-	CFLAGS 	+= $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(shell pkg-config --libs opencv)
+	OPENCV4 = $(shell pkg-config --cflags opencv4)
+	ifeq ($(OPENCV4)N, N)
+		CFLAGS 	+= $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(shell pkg-config --libs opencv)
+	else
+		CFLAGS 	+= $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(shell pkg-config --libs opencv4)
+	endif
 	OPENCV_LIB_DIR  += $(shell pkg-config --libs opencv | sed s/"-lopencv_.*"/""/g | sed s/"libopencv.*"/""/g | sed s/"-L"/""/g | sed s/" "/""/g)
 endif
 ifeq ($(OPENMP_ON), Y)


### PR DESCRIPTION
Fixed compile error on Ubuntu 20.04 and 22.04, which contain new g++ and OpenCV 4.0 or later.